### PR TITLE
SGi Token to Safe Tokenlist

### DIFF
--- a/src/tokens/SGi.json
+++ b/src/tokens/SGi.json
@@ -1,0 +1,8 @@
+{
+  "chainId": 1,
+  "address": "0x0418fa3488d7e13f0c06ac5f8485d306b5748f4f",
+  "name": "SmartGolf Token",
+  "symbol": "SGi",
+  "decimals": 18,
+  "logoURI": "https://smartgolf.io/wp-content/uploads/2025/09/Token-Logo.png"
+}

--- a/src/tokens/SGi.json
+++ b/src/tokens/SGi.json
@@ -4,5 +4,5 @@
   "name": "SmartGolf Token",
   "symbol": "SGi",
   "decimals": 18,
-  "logoURI": "https://smartgolf.io/wp-content/uploads/2025/09/Token-Logo.png"
+  "logoURI": "https://smartgolf.io/wp-content/uploads/2025/09/SGi-token-.png"
 }


### PR DESCRIPTION
Add SmartGolf Token (SGi) to the Safe default token list.

- ERC20 on Ethereum Mainnet
- Contract: 0x0418fa3488d7e13f0c06ac5f8485d306b5748f4f
- Name: SmartGolf Token
- Symbol: SGi
- Decimals: 18
- LogoURI: https://smartgolf.io/wp-content/uploads/2025/09/SGi-token-.png